### PR TITLE
Expose proxy settings

### DIFF
--- a/src/background/proxy/proxy.ts
+++ b/src/background/proxy/proxy.ts
@@ -5,9 +5,9 @@
 
 import { log } from '../../common/logger';
 import { browserApi } from '../browserApi';
-import { notifier } from '../../common/notifier';
 import { NON_ROUTABLE_CIDR_NETS } from '../routability/constants';
 import { fallbackApi } from '../api/fallbackApi';
+import { notifier } from '../../common/notifier';
 import {
     type EndpointInterface,
     type LocationInterface,
@@ -22,6 +22,7 @@ import { stateStorage } from '../stateStorage';
 
 import { DEFAULT_EXCLUSIONS, LEVELS_OF_CONTROL } from './proxyConsts';
 import { proxyApi } from './abstractProxyApi';
+import { proxyUserSettings } from './proxyUserSettings';
 
 const CURRENT_ENDPOINT_KEY = 'proxyCurrentEndpoint';
 
@@ -53,6 +54,7 @@ class ExtensionProxy implements ExtensionProxyInterface {
     state: ProxyState;
 
     async init(): Promise<void> {
+        await proxyUserSettings.init();
         this.state = stateStorage.getItem(StorageKey.ProxyState);
 
         if (!this.currentConfig) {
@@ -201,9 +203,11 @@ class ExtensionProxy implements ExtensionProxyInterface {
                 ...await fallbackApi.getApiUrlsExclusions(),
             ],
             nonRoutableCidrNets: NON_ROUTABLE_CIDR_NETS,
-            host: this.currentHost || PROXY_DEFAULTS.currentHost,
-            port: PROXY_CONFIG_PORT,
-            scheme: PROXY_CONFIG_SCHEME,
+            host: this.currentHost
+                || proxyUserSettings.getProxyHost()
+                || PROXY_DEFAULTS.currentHost,
+            port: proxyUserSettings.getProxyPort() || PROXY_CONFIG_PORT,
+            scheme: proxyUserSettings.getProxyScheme() || PROXY_CONFIG_SCHEME,
             inverted: this.inverted || false,
             credentials: this.credentials,
         };

--- a/src/background/proxy/proxyUserSettings.ts
+++ b/src/background/proxy/proxyUserSettings.ts
@@ -1,0 +1,40 @@
+import { browserApi } from '../browserApi';
+import { SETTINGS_IDS } from '../../common/constants';
+
+const STORAGE_KEY = 'proxy.user.settings';
+
+interface ProxyUserSettings {
+    [SETTINGS_IDS.PROXY_HOST]: string;
+    [SETTINGS_IDS.PROXY_PORT]: number;
+    [SETTINGS_IDS.PROXY_SCHEME]: string;
+}
+
+const defaults: ProxyUserSettings = {
+    [SETTINGS_IDS.PROXY_HOST]: '',
+    [SETTINGS_IDS.PROXY_PORT]: 443,
+    [SETTINGS_IDS.PROXY_SCHEME]: 'https',
+};
+
+let cache: ProxyUserSettings = { ...defaults };
+
+const init = async () => {
+    try {
+        const stored = await browserApi.storage.get<ProxyUserSettings>(STORAGE_KEY);
+        if (stored) {
+            cache = { ...cache, ...stored };
+        }
+    } catch (e) {
+        // ignore
+    }
+};
+
+const getProxyHost = () => cache[SETTINGS_IDS.PROXY_HOST];
+const getProxyPort = () => cache[SETTINGS_IDS.PROXY_PORT];
+const getProxyScheme = () => cache[SETTINGS_IDS.PROXY_SCHEME];
+
+export const proxyUserSettings = {
+    init,
+    getProxyHost,
+    getProxyPort,
+    getProxyScheme,
+};

--- a/src/background/settings/settings.ts
+++ b/src/background/settings/settings.ts
@@ -23,7 +23,7 @@ export interface SettingsInterface {
     disableProxy(force?: boolean): Promise<void>;
     enableProxy(force?: boolean): Promise<void>;
     isProxyEnabled(): boolean;
-    SETTINGS_IDS: { [key: string]: boolean | string };
+    SETTINGS_IDS: { [key: string]: boolean | string | number };
     applySettings(): void;
     getExclusions (): PersistedExclusions;
     setExclusions(exclusions: PersistedExclusions): void;
@@ -35,6 +35,9 @@ export interface SettingsInterface {
     getQuickConnectSetting(): QuickConnectSetting;
     getAppearanceTheme(): AppearanceTheme;
     isHelpUsImproveEnabled(): boolean;
+    getProxyHost(): string;
+    getProxyPort(): number;
+    getProxyScheme(): string;
 }
 
 const DEFAULT_SETTINGS = {
@@ -51,6 +54,9 @@ const DEFAULT_SETTINGS = {
     [SETTINGS_IDS.CUSTOM_DNS_SERVERS]: [],
     [SETTINGS_IDS.QUICK_CONNECT]: QUICK_CONNECT_SETTING_DEFAULT,
     [SETTINGS_IDS.DEBUG_MODE_ENABLED]: false,
+    [SETTINGS_IDS.PROXY_HOST]: '',
+    [SETTINGS_IDS.PROXY_PORT]: 443,
+    [SETTINGS_IDS.PROXY_SCHEME]: 'https',
 };
 
 const settingsService = new SettingsService(browserApi.storage, DEFAULT_SETTINGS);
@@ -189,6 +195,18 @@ const isHelpUsImproveEnabled = (): boolean => {
     return settingsService.getSetting(SETTINGS_IDS.HELP_US_IMPROVE);
 };
 
+const getProxyHost = (): string => {
+    return settingsService.getSetting(SETTINGS_IDS.PROXY_HOST);
+};
+
+const getProxyPort = (): number => {
+    return settingsService.getSetting(SETTINGS_IDS.PROXY_PORT);
+};
+
+const getProxyScheme = (): string => {
+    return settingsService.getSetting(SETTINGS_IDS.PROXY_SCHEME);
+};
+
 const init = async (): Promise<void> => {
     await settingsService.init();
     dns.init();
@@ -214,4 +232,7 @@ export const settings: SettingsInterface = {
     isDebugModeEnabled,
     getAppearanceTheme,
     isHelpUsImproveEnabled,
+    getProxyHost,
+    getProxyPort,
+    getProxyScheme,
 };

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -16,6 +16,9 @@ export const SETTINGS_IDS = {
     CUSTOM_DNS_SERVERS: 'custom.dns.servers',
     QUICK_CONNECT: 'quick.connect',
     DEBUG_MODE_ENABLED: 'debug.mode.enabled',
+    PROXY_HOST: 'proxy.host',
+    PROXY_PORT: 'proxy.port',
+    PROXY_SCHEME: 'proxy.scheme',
 };
 
 export const enum AppearanceTheme {

--- a/tests/background/appStatus/appStatus.test.ts
+++ b/tests/background/appStatus/appStatus.test.ts
@@ -20,6 +20,10 @@ const buildSettings = (proxyEnabled: boolean): SettingsInterface => {
         // @ts-ignore - mock async method with jest.fn
         disableProxy: jest.fn(() => {
         }),
+        // proxy configuration getters
+        getProxyHost: () => '',
+        getProxyPort: () => 443,
+        getProxyScheme: () => 'https',
     };
 };
 


### PR DESCRIPTION
## Summary
- add proxy host/port/scheme settings identifiers
- expose proxy configuration parameters via settings
- provide proxy user settings service
- update tests

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68410d85cc40832f8e35c62e5a835d13